### PR TITLE
fix: security hardening and dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a11y-mcp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "src/index.js",
   "type": "module",
   "bin": {
@@ -21,10 +21,9 @@
   "license": "MPL-2.0",
   "description": "MCP server for performing accessibility audits on webpages",
   "dependencies": {
-    "@axe-core/puppeteer": "^4.10.1",
-    "@modelcontextprotocol/create-server": "^0.3.1",
-    "@modelcontextprotocol/sdk": "^1.9.0",
-    "axe-core": "^4.10.3",
-    "puppeteer": "^24.6.0"
+    "@axe-core/puppeteer": "^4.11.1",
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "axe-core": "^4.11.1",
+    "puppeteer": "^24.40.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,9 @@ import puppeteer from 'puppeteer';
 import { AxePuppeteer } from '@axe-core/puppeteer';
 
 /**
- * Validate that a URL is safe to navigate to (SSRF protection).
- * Only allows http/https schemes and blocks requests to internal networks.
+ * Validate that a URL is safe to navigate to.
+ * Allows localhost and private networks (needed for auditing local dev servers).
+ * Blocks cloud metadata endpoints and non-http schemes.
  */
 async function validateUrl(urlString) {
   let parsed;
@@ -23,65 +24,98 @@ async function validateUrl(urlString) {
     throw new Error('Invalid URL format');
   }
 
-  // Only allow http and https schemes
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new Error(`Disallowed URL scheme: ${parsed.protocol}`);
   }
 
   const hostname = parsed.hostname;
 
-  // Block obvious localhost/loopback hostnames
-  const blockedHostnames = ['localhost', '127.0.0.1', '::1', '0.0.0.0', '[::1]'];
-  if (blockedHostnames.includes(hostname.toLowerCase())) {
-    throw new Error('URLs pointing to loopback addresses are not allowed');
-  }
-
-  // Resolve the hostname and check the resulting IP
+  // Resolve DNS and block cloud metadata endpoints
   let address;
   try {
-    const result = await lookup(hostname);
-    address = result.address;
+    // IP literals don't need resolution
+    if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.startsWith('[')) {
+      address = hostname.replace(/^\[|\]$/g, '');
+    } else {
+      const result = await lookup(hostname);
+      address = result.address;
+    }
   } catch {
     throw new Error(`Unable to resolve hostname: ${hostname}`);
   }
 
-  if (isPrivateIP(address)) {
-    throw new Error('URLs pointing to private or internal network addresses are not allowed');
+  if (isCloudMetadataIP(address)) {
+    throw new Error('URLs pointing to cloud metadata endpoints are not allowed');
   }
 
   return parsed;
 }
 
 /**
- * Check if an IP address belongs to a private, loopback, or link-local range.
+ * Check if an IP resolves to a cloud metadata endpoint (169.254.169.254)
+ * or other dangerous link-local destinations. Handles IPv4-mapped IPv6.
  */
-function isPrivateIP(ip) {
-  // IPv4 checks
-  const parts = ip.split('.').map(Number);
-  if (parts.length === 4 && parts.every(p => p >= 0 && p <= 255)) {
-    // 127.0.0.0/8 — loopback
-    if (parts[0] === 127) return true;
-    // 10.0.0.0/8 — private
-    if (parts[0] === 10) return true;
-    // 172.16.0.0/12 — private
-    if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
-    // 192.168.0.0/16 — private
-    if (parts[0] === 192 && parts[1] === 168) return true;
-    // 169.254.0.0/16 — link-local / cloud metadata
-    if (parts[0] === 169 && parts[1] === 254) return true;
-    // 0.0.0.0/8
-    if (parts[0] === 0) return true;
+function isCloudMetadataIP(ip) {
+  const normalized = extractIPv4FromMapped(ip);
+
+  if (normalized) {
+    const parts = normalized.split('.').map(Number);
+    if (parts.length === 4 && parts.every(p => p >= 0 && p <= 255)) {
+      // 169.254.169.254 — cloud metadata (AWS, GCP, Azure)
+      if (parts[0] === 169 && parts[1] === 254 && parts[2] === 169 && parts[3] === 254) return true;
+    }
   }
 
-  // IPv6 loopback
-  if (ip === '::1' || ip === '0:0:0:0:0:0:0:1') return true;
-  // IPv6 link-local
-  if (ip.toLowerCase().startsWith('fe80:')) return true;
-  // IPv6 unique local (fc00::/7)
-  const first2 = ip.toLowerCase().slice(0, 2);
-  if (first2 === 'fc' || first2 === 'fd') return true;
-
   return false;
+}
+
+/**
+ * Extract IPv4 address from IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254),
+ * or return the IP as-is if it's already IPv4. Returns null for pure IPv6.
+ */
+function extractIPv4FromMapped(ip) {
+  // Plain IPv4
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(ip)) return ip;
+  // IPv4-mapped IPv6: ::ffff:x.x.x.x
+  const mapped = ip.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (mapped) return mapped[1];
+  return null;
+}
+
+/**
+ * Intercept Puppeteer network requests to enforce URL policy at navigation time,
+ * preventing DNS rebinding attacks.
+ */
+async function setupRequestInterception(page) {
+  await page.setRequestInterception(true);
+  page.on('request', async (request) => {
+    try {
+      const url = new URL(request.url());
+      // Only intercept navigations and document requests
+      if (request.isNavigationRequest()) {
+        const hostname = url.hostname;
+        let address;
+        try {
+          if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.startsWith('[')) {
+            address = hostname.replace(/^\[|\]$/g, '');
+          } else {
+            const result = await lookup(hostname);
+            address = result.address;
+          }
+        } catch {
+          request.abort('namenotresolved');
+          return;
+        }
+        if (isCloudMetadataIP(address)) {
+          request.abort('accessdenied');
+          return;
+        }
+      }
+      request.continue();
+    } catch {
+      request.continue();
+    }
+  });
 }
 
 class A11yServer {
@@ -99,7 +133,7 @@ class A11yServer {
     );
 
     this.setupToolHandlers();
-    
+
     // Error handling
     this.server.onerror = (error) => console.error('[MCP Error]', error);
     process.on('SIGINT', async () => {
@@ -177,37 +211,30 @@ class A11yServer {
       );
     }
 
+    let browser;
     try {
-      // Validate URL to prevent SSRF
       const validatedUrl = await validateUrl(args.url);
 
-      const browser = await puppeteer.launch({
+      browser = await puppeteer.launch({
         headless: 'new',
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
       });
       const page = await browser.newPage();
 
-      // Set a reasonable viewport
+      await setupRequestInterception(page);
       await page.setViewport({ width: 1280, height: 800 });
-
-      // Navigate to the page using the validated URL
       await page.goto(validatedUrl.href, { waitUntil: 'networkidle2', timeout: 30000 });
 
-      // Run axe on the page
       const axeOptions = {};
-      if (args.tags && args.tags.length > 0) {
+      if (Array.isArray(args.tags) && args.tags.length > 0) {
         axeOptions.runOnly = {
           type: 'tag',
           values: args.tags,
         };
       }
-      
+
       const results = await new AxePuppeteer(page).options(axeOptions).analyze();
-      
-      // Close the browser
-      await browser.close();
-      
-      // Format the results
+
       const formattedResults = {
         url: args.url,
         timestamp: new Date().toISOString(),
@@ -223,22 +250,22 @@ class A11yServer {
                 target: node.target,
                 failureSummary: node.failureSummary,
               };
-              
-              if (args.includeHtml) {
+
+              if (args.includeHtml === true) {
                 formattedNode.html = node.html;
               }
-              
+
               return formattedNode;
             }),
           };
-          
+
           return formattedViolation;
         }),
         passes: results.passes.length,
         incomplete: results.incomplete.length,
         inapplicable: results.inapplicable.length,
       };
-      
+
       return {
         content: [
           {
@@ -248,15 +275,20 @@ class A11yServer {
         ],
       };
     } catch (error) {
+      console.error('[audit_webpage]', error);
       return {
         content: [
           {
             type: 'text',
-            text: `Error auditing webpage: ${error.message}`,
+            text: `Error auditing webpage: ${sanitizeErrorMessage(error.message)}`,
           },
         ],
         isError: true,
       };
+    } finally {
+      if (browser) {
+        await browser.close().catch(() => {});
+      }
     }
   }
 
@@ -268,29 +300,22 @@ class A11yServer {
       );
     }
 
+    let browser;
     try {
-      // Validate URL to prevent SSRF
       const validatedUrl = await validateUrl(args.url);
 
-      const browser = await puppeteer.launch({
+      browser = await puppeteer.launch({
         headless: 'new',
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
       });
       const page = await browser.newPage();
 
-      // Set a reasonable viewport
+      await setupRequestInterception(page);
       await page.setViewport({ width: 1280, height: 800 });
-
-      // Navigate to the page using the validated URL
       await page.goto(validatedUrl.href, { waitUntil: 'networkidle2', timeout: 30000 });
 
-      // Run axe on the page
       const results = await new AxePuppeteer(page).analyze();
-      
-      // Close the browser
-      await browser.close();
-      
-      // Create a summary
+
       const summary = {
         url: args.url,
         timestamp: new Date().toISOString(),
@@ -316,7 +341,7 @@ class A11yServer {
         passedTests: results.passes.length,
         incompleteTests: results.incomplete.length,
       };
-      
+
       return {
         content: [
           {
@@ -326,15 +351,20 @@ class A11yServer {
         ],
       };
     } catch (error) {
+      console.error('[get_summary]', error);
       return {
         content: [
           {
             type: 'text',
-            text: `Error getting summary: ${error.message}`,
+            text: `Error getting summary: ${sanitizeErrorMessage(error.message)}`,
           },
         ],
         isError: true,
       };
+    } finally {
+      if (browser) {
+        await browser.close().catch(() => {});
+      }
     }
   }
 
@@ -343,6 +373,16 @@ class A11yServer {
     await this.server.connect(transport);
     console.error('A11y Accessibility MCP server running on stdio');
   }
+}
+
+/**
+ * Strip file paths and stack trace details from error messages
+ * to avoid leaking internal server information.
+ */
+function sanitizeErrorMessage(message) {
+  if (!message) return 'An unexpected error occurred';
+  // Remove absolute file paths
+  return message.replace(/\/[^\s:]+/g, '<path>').replace(/[A-Z]:\\[^\s:]+/g, '<path>');
 }
 
 const server = new A11yServer();


### PR DESCRIPTION
## Summary
- **Browser resource leak**: Added `try/finally` to ensure `browser.close()` runs on all code paths
- **DNS rebinding**: Added Puppeteer request interception to re-validate DNS at navigation time
- **IPv4-mapped IPv6 bypass**: `::ffff:169.254.169.254` is now correctly detected
- **Cloud metadata only**: Replaced blanket private-IP block with targeted `169.254.169.254` block — **localhost auditing still works**
- **Error info disclosure**: Error messages are sanitized to strip file paths; full errors logged to stderr
- **Input validation**: Strict `Array.isArray()` and `=== true` type checks
- **Removed unused dep**: `@modelcontextprotocol/create-server`
- **Updated deps**: SDK `^1.27.1` (fixes 2 high advisories), puppeteer `^24.40.0`, axe-core `^4.11.1`
- **0 npm audit vulnerabilities**

## Test results
```
Tools: audit_webpage, get_summary ✅
Block cloud metadata (169.254.169.254) ✅
Block file:// scheme ✅
Allow localhost (not blocked, connection attempted) ✅
get_summary on example.com (2 issues, 13 passes) ✅
```

## Test plan
- [x] MCP server initializes and lists tools
- [x] Cloud metadata URL is blocked
- [x] `file://` scheme is blocked
- [x] `localhost` URLs are allowed
- [x] Real public URL audit works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)